### PR TITLE
Initial support for "configuration only" images. 

### DIFF
--- a/dockerutils/image_conventions.py
+++ b/dockerutils/image_conventions.py
@@ -38,7 +38,10 @@ def get_image_designation(image, config=None):
 def get_image_name(config, image):
     if image in config.sections():
         if 'name' in config[image]:
-            return f'{get_default_project_name()}-{config[image]["name"]}'
+            if 'prefix' in config[image] and not config[image]['prefix'] in ['False', 'false', 'F', 'f']:
+                return f'{get_default_project_name()}-{config[image]["name"]}'
+            else:
+                return f'{config[image]["name"]}'
     return f'{get_default_project_name()}-{image}'
 
 

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -84,7 +84,12 @@ if __name__ == '__main__':
         config.optionxform = str
         config.read(os.path.join('docker', 'dockerutils.cfg'))
 
-        gen_version_file()
+        if os.path.isfile('setup.cfg'):
+            config = configparser.ConfigParser()
+            config.optionxform = str
+            config.read('setup.cfg')
+            if 'versioneer' in config:
+                gen_version_file()
 
         with pip_conf(root_dir):
             image_types = get_image_types()
@@ -125,8 +130,9 @@ if __name__ == '__main__':
                     if 'pull_FROM_on_force' in image_config:
                         pull_FROM_on_force = config[image]['pull_FROM_on_force']
 
-                rc = fn(image, image_name, image_tag, config=image_config, pull=args.pull_base or (args.force_build_base and pull_FROM_on_force))
-                # because an image may not be present on the clean, ignore a non-zero return code
-                if rc and not args.image == 'clean':
-                    sys.exit(rc)
+                if os.path.isfile(f'docker/{image}/Dockerfile'):
+                    rc = fn(image, image_name, image_tag, config=image_config, pull=args.pull_base or (args.force_build_base and pull_FROM_on_force))
+                    # because an image may not be present on the clean, ignore a non-zero return code
+                    if rc and not args.image == 'clean':
+                        sys.exit(rc)
     sys.exit(0)

--- a/scripts/dock-sync
+++ b/scripts/dock-sync
@@ -65,11 +65,13 @@ function sync-up() {
         genversion
 
         # get the version file
-        local VER_FILE=$(get_version_file)
+        if [ -n "$PWD/setup.cfg" ]; then
+            local VER_FILE=$(get_version_file)
 
-        if [ -n "$VER_FILE" ]; then
-            # finally sync _version.py.bld into the version file
-            do-sync-up $PWD/_version.py.bld ubuntu@$DOCKER_IP:/data/workspaces/$USER/code/$VER_FILE
+            if [ -n "$VER_FILE" ]; then
+                # finally sync _version.py.bld into the version file
+                do-sync-up $PWD/_version.py.bld ubuntu@$DOCKER_IP:/data/workspaces/$USER/code/$VER_FILE
+            fi
         fi
     fi
     return 0
@@ -77,8 +79,11 @@ function sync-up() {
 
 function sync-down() {
     # if we have a proxy version file, ignore it on the sync down
-    local VER_FILE=$(get_version_file)
-    VER_FILE=${VER_FILE#*/}
+    local VER_FILE=
+    if [ -n "$PWD/setup.cfg" ]; then
+        VER_FILE=$(get_version_file)
+        VER_FILE=${VER_FILE#*/}
+    fi
     do-sync-down "ubuntu@$DOCKER_IP:/data/workspaces/$(whoami)/code/${PWD##*/}/*" . ${VER_FILE:+$VER_FILE}
     return 0
 }


### PR DESCRIPTION
This PR supports two things:

1) Make versioneer optional
2) Adds support for "Configuration only" images. You can have an image defined strictly in dockerutils.cfg (aside from the fact that you'll need a placeholder directory in the docker directory) and provide configuration to allow it to run as specified. (Found this useful for running notebooks against a project without having to define a notebook image, but desiring non-standard configuration, e.g. mapping data files, etc.)